### PR TITLE
add manjaro.layout and redmond-no-indicators.layout support

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -1181,6 +1181,19 @@ class MateTweak:
            not self.indicators_available:
             panels.append([_("Netbook (no indicators)"), "netbook-no-indicators"])
 
+        if self.panel_layout_exists('mutiny-no-indicators') and \
+           self.mate_dock_available and \
+           self.appmenu_applet_available and \
+           not self.indicators_available:
+            panels.append([_("Mutiny"), "mutiny-no-indicators"])
+
+        if self.dock is not None and \
+           self.appmenu_applet_available and \
+           self.brisk_menu_available and \
+           not self.indicators_available:
+            if self.panel_layout_exists('eleven-no-indicators'):
+                panels.append([_("Cupertino (no indicators)"), "eleven-no-indicators"])
+
         self.builder.get_object("combobox_panels").set_model(panels)
 
     def ask_for_layout_name(self):

--- a/mate-tweak
+++ b/mate-tweak
@@ -1185,7 +1185,7 @@ class MateTweak:
            self.mate_dock_available and \
            self.appmenu_applet_available and \
            not self.indicators_available:
-            panels.append([_("Mutiny"), "mutiny-no-indicators"])
+            panels.append([_("Mutiny (no indicators)"), "mutiny-no-indicators"])
 
         if self.dock is not None and \
            self.appmenu_applet_available and \

--- a/mate-tweak
+++ b/mate-tweak
@@ -1163,6 +1163,9 @@ class MateTweak:
         if self.panel_layout_exists('solus') and \
            self.brisk_menu_available:
             panels.append([_("Solus"), "solus"])
+            
+        if self.panel_layout_exists('manjaro'):
+            panels.append([_("Manjaro"), "manjaro"])
 
         if self.panel_layout_exists('ubuntu-mate'):
             panels.append([_("Traditional"), "ubuntu-mate"])

--- a/mate-tweak
+++ b/mate-tweak
@@ -1161,10 +1161,6 @@ class MateTweak:
            self.indicators_available:
             panels.append([_("Redmond"), "redmond"])
 
-        if self.panel_layout_exists('redmond-no-indicators') and \
-           not self.indicators_available:
-            panels.append([_("Redmond (No indicators)"), "redmond-no-indicators"])
-
         if self.panel_layout_exists('solus') and \
            self.brisk_menu_available:
             panels.append([_("Solus"), "solus"])

--- a/mate-tweak
+++ b/mate-tweak
@@ -1160,6 +1160,10 @@ class MateTweak:
            self.indicators_available:
             panels.append([_("Redmond"), "redmond"])
 
+        if self.panel_layout_exists('redmond-no-indicators') and \
+           not self.indicators_available:
+            panels.append([_("Redmond (No indicators)"), "redmond-no-indicators"])
+
         if self.panel_layout_exists('solus') and \
            self.brisk_menu_available:
             panels.append([_("Solus"), "solus"])

--- a/mate-tweak
+++ b/mate-tweak
@@ -1038,9 +1038,10 @@ class MateTweak:
         if os.path.exists('/usr/lib/mate-menu/mate-menu.py'):
             self.mate_menu_available = True
 
-        if os.path.exists('/usr/lib/' + self.multiarch + '/brisk-menu/brisk-menu') and \
-            os.path.exists('/usr/share/mate-panel/applets/com.solus_project.brisk.BriskMenu.mate-panel-applet'):
-            self.brisk_menu_available = True
+        if os.path.exists('/usr/lib/' + self.multiarch + '/brisk-menu/brisk-menu') or \
+            os.path.exists('/usr/lib/' + '/brisk-menu/brisk-menu'):
+            if os.path.exists('/usr/share/mate-panel/applets/com.solus_project.brisk.BriskMenu.mate-panel-applet'):
+             self.brisk_menu_available = True
 
         if os.path.exists('/usr/lib/mate-panel/appmenu-mate') and \
             os.path.exists('/usr/share/mate-panel/applets/org.vala-panel.appmenu.mate-panel-applet'):
@@ -1167,12 +1168,22 @@ class MateTweak:
         if self.panel_layout_exists('solus') and \
            self.brisk_menu_available:
             panels.append([_("Solus"), "solus"])
-            
-        if self.panel_layout_exists('manjaro'):
-            panels.append([_("Manjaro"), "manjaro"])
 
         if self.panel_layout_exists('ubuntu-mate'):
             panels.append([_("Traditional"), "ubuntu-mate"])
+
+        if self.panel_layout_exists('manjaro') and \
+           self.brisk_menu_available:
+            panels.append([_("Manjaro"), "manjaro"])
+
+        if self.panel_layout_exists('redmond-no-indicators') and \
+           not self.indicators_available:
+            panels.append([_("Redmond (no indicators)"), "redmond-no-indicators"])
+
+        if self.panel_layout_exists('netbook-no-indicators') and \
+           self.maximus_available and \
+           not self.indicators_available:
+            panels.append([_("Netbook (no indicators)"), "netbook-no-indicators"])
 
         self.builder.get_object("combobox_panels").set_model(panels)
 


### PR DESCRIPTION
The manjaro.layout is very similar to the Solus' one. It is included in the **manjaro-mate-panel-layout** package in the manjaro repositories. I wanted to also add the line:
```
      self.brisk_menu_available:
```

Similar to the solus layout. However, for some reason it doesn't recognize it that way. In order to make it work I have to change the line 1041:
```
if os.path.exists('/usr/lib/' + self.multiarch + '/brisk-menu/brisk-menu') and \
  os.path.exists('/usr/share/mate-panel/applets/com.solus_project.brisk.BriskMenu.mate-panel-applet'):
  self.brisk_menu_available = True
```

and remove the text **+ self.multiarch**. I don't understand what exactly that does, but the brisk-menu exists on the path **/usr/lib/brisk-menu/brisk-menu**. So, I just skipped the **self.brisk_menu_available** check. Any idea how I can fix that? 