### PR TITLE
setup.py: fix desktop entries' location for non-ubuntu distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,12 +55,12 @@ def datafilelist(installbase, sourcebase):
 data_files = [
     ('{prefix}/share/man/man1'.format(prefix=sys.prefix), glob('data/*.1')),
     ('{prefix}/share/applications'.format(prefix=sys.prefix), ['data/mate-tweak.desktop',]),
-    ('{prefix}/share/mate/applications'.format(prefix=sys.prefix), ['data/marco-compton.desktop',]),
-    ('{prefix}/share/mate/applications'.format(prefix=sys.prefix), ['data/marco-xcompmgr.desktop',]),
-    ('{prefix}/share/mate/applications'.format(prefix=sys.prefix), ['data/metacity-compton.desktop',]),
-    ('{prefix}/share/mate/applications'.format(prefix=sys.prefix), ['data/metacity-xcompmgr.desktop',]),
-    ('{prefix}/share/mate/applications'.format(prefix=sys.prefix), ['data/marco-no-composite.desktop',]),
-    ('{prefix}/share/mate/applications'.format(prefix=sys.prefix), ['data/metacity-no-composite.desktop',]),
+    ('{prefix}/share/applications'.format(prefix=sys.prefix), ['data/marco-compton.desktop',]),
+    ('{prefix}/share/applications'.format(prefix=sys.prefix), ['data/marco-xcompmgr.desktop',]),
+    ('{prefix}/share/applications'.format(prefix=sys.prefix), ['data/metacity-compton.desktop',]),
+    ('{prefix}/share/applications'.format(prefix=sys.prefix), ['data/metacity-xcompmgr.desktop',]),
+    ('{prefix}/share/applications'.format(prefix=sys.prefix), ['data/marco-no-composite.desktop',]),
+    ('{prefix}/share/applications'.format(prefix=sys.prefix), ['data/metacity-no-composite.desktop',]),
     ('{prefix}/share/polkit-1/actions'.format(prefix=sys.prefix), ['data/org.mate.mate-tweak.policy',]),
     ('{prefix}/lib/mate-tweak'.format(prefix=sys.prefix), ['data/mate-tweak.ui', 'util/disable-mate-volume-applet', 'util/mate-panel-backup', 'util/install-mate-panel-layout']),
 ]


### PR DESCRIPTION
This PR addresses this: https://github.com/ubuntu-mate/mate-tweak/issues/30

Tell me what you think