### PR TITLE
Do not use uninitialised properties on startup

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -1513,7 +1513,7 @@ class MateTweak:
         self.builder.get_object("checkbox_localmenu").set_tooltip_text(_("Display application menus in the application window. When local menus are disabled, add the Global Menu applet to a panel to see them."))
 
         # Locally integrated menus
-        if self.schema_has_key('org.mate.interface', 'gtk-shell-shows-menubar'):
+        if self.schema_has_key('org.mate.interface', 'gtk-shell-shows-menubar') and self.appmenu_available:
             self.builder.get_object("checkbox_localmenu").connect("toggled", self.toggle_localmenu)
             self.builder.get_object("checkbox_localmenu").set_active(self.show_localmenu)
         else:


### PR DESCRIPTION
This alleviates a crash on startup when the appmenu module isn't actually
installed.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>