### PR TITLE
Fixing broken shadows on Firefox and ulauncher

### DIFF
--- a/marco-compton
+++ b/marco-compton
@@ -61,6 +61,8 @@ else
         --shadow-exclude "class_g = 'Conky'" \
         --shadow-exclude "class_g = 'Kupfer'" \
         --shadow-exclude "class_g = 'Synapse'" \
+        --shadow-exclude "class_g = 'Firefox' && argb" \
+        --shadow-exclude "class_g = 'Ulauncher'" \
         --shadow-exclude "class_g ?= 'Notify-osd'" \
         --shadow-exclude "class_g ?= 'Cairo-dock'" \
         --shadow-exclude "class_g = 'Cairo-clock'" \


### PR DESCRIPTION
Compton will draw a drop shadow on Firefox's menu which looks very broken since Firefox will _also_ draw a shadow under the window. Same for ulauncher.