### PR TITLE
Remove clear shadow

### DIFF
--- a/marco-compton
+++ b/marco-compton
@@ -46,7 +46,6 @@ else
         --use-ewmh-active-win \
         -r 10 -o 0.225 -l -12 -t -12 \
         -c -C -G \
-        --clear-shadow \
         --fading \
         --fade-delta=4 \
         --fade-in-step=0.03 \


### PR DESCRIPTION
This seems to affect how some shadows are positioned,
leading to a clear space between the window and its
shadow.

Fixes #62 

Before:
![with-clear-shadow](https://user-images.githubusercontent.com/259780/60913659-df131380-a255-11e9-870d-c54a626f939a.png)

After:
![without-clear-shadow](https://user-images.githubusercontent.com/259780/60913674-e3d7c780-a255-11e9-866b-272b42105c5e.png)
