### PR TITLE
add mate_menu dependency on opensuse layout

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -1303,6 +1303,7 @@ class MateTweak:
             self.add_to_panel_list(panels, "Netbook", "netbook-no-indicators")
 
         if self.panel_layout_exists('opensuse') and \
+           self.mate_menu_available and \
            not self.indicators_available:
             self.add_to_panel_list(panels, "openSUSE", "opensuse")
 


### PR DESCRIPTION
only show opensuse layout when matemenu available.
https://github.com/mate-desktop/mate-panel/blob/master/data/opensuse.layout