### PR TITLE
Set spacing in confirm dialog to 12

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -780,7 +780,7 @@ class MateTweak:
         label.set_use_markup(True)
 
         box = dialog.get_content_area()
-        box.set_border_width(8)
+        box.set_border_width(12)
         box.add(label)
         dialog.show_all()
 


### PR DESCRIPTION
Ubuntu MATE doesn't appear to have a HIG. However, it's at least vaguely modelled on Gnome 2, and [the HIG for Gnome 2](https://developer.gnome.org/hig-book/3.12/windows-alert.html.en#alert-spacing) dictates a spacing of 12px around the edges of alert windows. This would prevent MATE Tweak confirmation dialogs (such as the one mentioned in issue #74) from looking weirdly spaced and cramped, and be generally more consistent overall.