### PR TITLE
Ensure .layout and .panel files have consistent object names

### DIFF
--- a/util/mate-tweak-helper
+++ b/util/mate-tweak-helper
@@ -60,7 +60,7 @@ def backup_layout(filename):
     VALID = {'toplevel': ('enable-buttons', 'expand', 'monitor', 'orientation', 'screen', 'size'),
              'launcher': ('object-type', 'launcher-location', 'menu-path', 'toplevel-id', 'position', 'panel-right-stick', 'locked'),
              'applet': ('object-type', 'applet-iid', 'toplevel-id', 'position', 'panel-right-stick', 'locked'),
-             'drawer': ('object-type', 'attached-toplevel-id', 'toplvel-id', 'position', 'panel-right-stick', 'use-custom-icon'),
+             'drawer': ('object-type', 'attached-toplevel-id', 'toplevel-id', 'position', 'panel-right-stick', 'use-custom-icon'),
              'menu-bar': ('object-type', 'applet-iid', 'toplevel-id', 'position', 'panel-right-stick', 'locked'),
              'menu': ('object-type', 'toplevel-id', 'position', 'panel-right-stick', 'locked'),
              'action': ('object-type', 'action-type', 'position', 'toplevel-id', 'panel-right-stick', 'locked'),

--- a/util/mate-tweak-helper
+++ b/util/mate-tweak-helper
@@ -57,7 +57,7 @@ def delete_layout(filename):
 
 
 def backup_layout(filename):
-    VALID = {'toplevel': ('expand', 'size', 'orientation'),
+    VALID = {'toplevel': ('enable-buttons', 'expand', 'monitor', 'orientation', 'screen', 'size'),
              'launcher': ('object-type', 'launcher-location', 'menu-path', 'toplevel-id', 'position', 'panel-right-stick', 'locked'),
              'applet': ('object-type', 'applet-iid', 'toplevel-id', 'position', 'panel-right-stick', 'locked'),
              'drawer': ('object-type', 'attached-toplevel-id', 'toplvel-id', 'position', 'panel-right-stick', 'use-custom-icon'),

--- a/util/mate-tweak-helper
+++ b/util/mate-tweak-helper
@@ -103,13 +103,7 @@ def backup_layout(filename):
 
         obj_toplevel = settings['toplevel-id']
         obj_type = settings['object-type']
-        obj_name = ""
-        if obj_type == "applet":
-            obj_name = settings['applet-iid'].split(":")[-1]
-        elif obj_type == "action":
-            obj_name = settings['action-type']
-        else:
-            obj_name = obj_type
+        obj_name = str(obj)
 
         if not obj_toplevel in toplevel_ids:
             print("WARNING! object \"%s\" references unknown toplevel... skipped" % obj_name)

--- a/util/mate-tweak-helper
+++ b/util/mate-tweak-helper
@@ -125,7 +125,7 @@ def backup_layout(filename):
                 layout.append("%s=%s\n" % (key, val))
         layout.append("\n")
 
-        layout.extend(get_non_panel_settings())
+    layout.extend(get_non_panel_settings())
 
     #print(layout)
     with open(os.path.join(tempfile.gettempdir(), filename + '.layout'), 'w') as f:


### PR DESCRIPTION
Make sure object names are distinctive and consistent between the `.layout` and `.panel`. Prevent duplication of non-panel custom settings. Store monitor/screen associations for top-levels.

Fixes https://pad.lv/1872255