### PR TITLE
Ignore case for Firefox

### DIFF
--- a/marco-wrapper
+++ b/marco-wrapper
@@ -76,7 +76,7 @@ if [ -n "${COMP}" ]; then
             --shadow-exclude "class_g = 'albert'" \
             --shadow-exclude "class_g = 'Cairo-clock'" \
             --shadow-exclude "class_g = 'Conky'" \
-            --shadow-exclude "class_g = 'Firefox' && argb" \
+            --shadow-exclude "class_g ?= 'Firefox' && argb" \
             --shadow-exclude "class_g ?= 'Notify-osd'" \
             --shadow-exclude "class_g = 'Synapse'" \
             --shadow-exclude "class_g = 'Ulauncher'" \


### PR DESCRIPTION
Recent Firefox versions shows as `firefox`
```
$ xprop WM_CLASS
WM_CLASS(STRING) = "Navigator", "firefox"
```