### PR TITLE
user-info at panel save: no custom launcher will be saved

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -1394,7 +1394,76 @@ class MateTweak:
                         index += 1
                     self.combobox_panels_handler = widget.connect("changed", self.combo_fallback, 'org.mate.panel', 'default-layout')
 
+    def get_locale(self):
+        langs = GLib.get_language_names()
+        for l in langs:
+            # find first without encoding
+            if l.find ('.') == -1 :
+                return l
+        return None
+
+    def save_panel__info_laucher_not_save(self):
+        title = _('Custom launcher not saved')
+        labelText = _('You have modified or created custom launchers in your panel. These will be not saved:')
+        path = os.path.join(GLib.get_user_config_dir(), 'mate', 'panel2.d', 'default', 'launchers', '');
+        text = ""
+        counter = 0
+        lang = self.get_locale();
+        # read the .desktop files
+        for fileName in glob.glob(path + '*.desktop'):
+            if fileName.strip() == '':
+                continue
+            counter += 1
+            f = open(fileName,'r')
+            lines = f.readlines()
+            pName = ''
+            pName_loc = None
+            pExecUrl = ''
+            for line in lines:
+                if line[0:4].lower() == "exec":
+                    pExecUrl += " - "+line[5:].strip()
+                if line[0:3].lower() == "url":
+                    pExecUrl += " - "+line[4:].strip()
+                if line[0:4].lower() == "name":
+                    if line[0:5].lower() == "name=" :
+                        pName = line[5:].strip()
+                    elif lang != None and line[0:5 + len(lang)].lower() == "name[" + lang.lower():
+                        pName_loc = line[line.find('=')+1:].strip()
+            if pName_loc != None:
+                pName = pName_loc # is more up-to-date
+            text += "\n"+str(counter)+".) " + (fileName.replace(path,'').replace('.desktop','').strip()) + ' - ' + pName + pExecUrl
+        if(text==""):
+            return Gtk.ResponseType.OK
+        dialog = Gtk.Dialog(title, None)
+        dialog.set_destroy_with_parent(True)
+        dialog.set_modal(True)
+        dialog.add_buttons(
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OK, Gtk.ResponseType.OK
+        )
+        dialog.set_default_size(250, 120)
+
+        label = Gtk.Label()
+        label.set_text(labelText)
+        label2 = Gtk.Label()
+        label2.set_markup(_('You can do yourself a backup of these files:') + ' <a href="file://' + path + '">' + path + '</a>\n' + _('To restore it again: First restore these files, than load the saved panel. Or, alternative: load panel , restore files , re-login.'))
+        scrolled_win = Gtk.ScrolledWindow()
+        textarea = Gtk.Label()
+        textarea.set_text(text.strip())
+        scrolled_win.add(textarea)
+        box = dialog.get_content_area()
+        box.set_border_width(8)
+        box.add(label)
+        box.add(scrolled_win)
+        box.add(label2)
+        dialog.show_all()
+        response = dialog.run()
+        dialog.destroy()
+        return response
+
     def save_panels(self, widget):
+        if self.save_panel__info_laucher_not_save() != Gtk.ResponseType.OK :
+            return None
         layoutname = self.ask_for_layout_name()
         if layoutname is not None:
             layoutnameprefix = self.get_custom_layout_file_prefix(self.current_layout)

--- a/po/de.po
+++ b/po/de.po
@@ -64,6 +64,28 @@ msgstr ""
 "Fensterverwaltung. Deswegen können wir nicht garantieren, dass hier "
 "eingegebene Änderungen übernommen werden."
 
+#: ../mate-tweak:
+msgid "Custom launcher not saved"
+msgstr "Angepasste Starter nicht gesichert"
+
+#: ../mate-tweak:
+msgid "You have modified or created custom launchers in your panel. These will be not saved:"
+msgstr ""
+"Sie haben benutzerdefinierte oder angepassten Anwendungsstarter im Panel hinterlegt. "
+"Diese werden nicht gespeichert:"
+
+#: ../mate-tweak:
+msgid "You can do yourself a backup of these files:"
+msgstr "Sie können selber eine Datensicherung machen von diesen Dateien:"
+
+#: ../mate-tweak:
+msgid ""
+"To restore it again: First restore these files, than load the "
+"saved panel. Or, alternative: load panel , restore files , re-login."
+msgstr ""
+"Wiederherstellung: Erst diese Dateien wiederherstellen, dann das gespeicherte Panel laden. "
+" Oder alternativ: lade Panel, wiederherstellen dieser Dateien, erneut einloggen)"
+
 #: ../mate-tweak:1529
 msgid "Desktop"
 msgstr "Schreibtisch"

--- a/po/mate-tweak.pot
+++ b/po/mate-tweak.pot
@@ -55,6 +55,24 @@ msgid ""
 "cannot guarantee that changes made here will be effective."
 msgstr ""
 
+#: ../mate-tweak:
+msgid "Custom launcher not saved"
+msgstr ""
+
+#: ../mate-tweak:
+msgid "You have modified or created custom launchers in your panel. These will be not saved:"
+msgstr ""
+
+#: ../mate-tweak:
+msgid "You can do yourself a backup of these files:"
+msgstr ""
+
+#: ../mate-tweak:
+msgid ""
+"To restore it again: First restore these files, than load the "
+"saved panel. Or, alternative: load panel , restore files , re-login."
+msgstr ""
+
 #: ../mate-tweak:1529
 msgid "Desktop"
 msgstr ""


### PR DESCRIPTION
When saving Panel-layout:
The custom / modified launcher in panel will be not saved: Warn the user, about this and list these items.

<img width="802" height="221" alt="custom_launcher_v4_sw_8f" src="https://github.com/user-attachments/assets/ff9f7cb5-fb45-4206-b674-cd7dd6a623b2" />


The same, as text-only:


```
You have modified or created custom launchers in your panel. These will be not saved:
 1.) Firefox - Firefox MyProfile2 starter - firefox -p myProfil2
 2.) myScript - ~/myscript.sh
 3.) caja - CajaRenamed - /usr/bin/caja --no-desktop --browser %U
 4.) example.com - Example Domain - http :// example . com\r
 5.( Quick-guide.html - Example-Website-viaDragAndDrop - http :// example . com/Quick-guide.html\r
 [...]
You can do yourself a backup of these files: ~/.config/mate/panel2.d/default/launchers\n
To restore it again: First restore these files, than load the saved panel. Or, alternative: load panel , restore files , re-login.
```

These are own custom launcher or modified default (application) launcher (e.g. rename, command changed). 