### PR TITLE
add post_uninstall.sh: reset window-manager to default

### DIFF
--- a/post_uninstall.sh
+++ b/post_uninstall.sh
@@ -1,0 +1,24 @@
+#/!/bin/bash
+# post_uninstall script for mate-tweak: reset the window manager
+# This will fix: After changing windowmanager and uninstall mate-tweak, you are maybe without any window-manager in mate.
+
+while read user; do
+    #has dconf?
+    sudo -u "$user" -H -s eval 'ls $HOME/.config/dconf 2>> /dev/null > /dev/null'
+    if [ "${?}" -eq "0" ]
+    then
+        wm=$(sudo -u "$user" -H gsettings get org.mate.session.required-components windowmanager | sed s/\'//g)
+        # echo $wm
+        if [ "$wm" = "marco-compton" ] || 
+           [ "$wm" = "marco-glx" ] ||
+           [ "$wm" = "marco-no-composite" ] || 
+           [ "$wm" = "marco-picom" ] || 
+           [ "$wm" = "marco-xrender" ] || 
+           [ "$wm" = "marco-xr_glx_hybrid" ]
+          then
+              echo "Reset to default window-manager ('marco') for user $user , because $wm was removed."
+              echo $(sudo -u "$user" -H dbus-run-session gsettings reset org.mate.session.required-components windowmanager)
+              # echo $(sudo -u "$user" -H gsettings get org.mate.session.required-components windowmanager)
+        fi
+    fi
+done < <(getent passwd | awk -F ':' '$3>=1000 {print $1}')


### PR DESCRIPTION
**Update:
I think a fix in [mate-session (issue)](https://github.com/mate-desktop/mate-session-manager/issues/324), is bedder.**

---------

After uninstall mate-tweak, you may are without any (active) Window-Manager.

Steps to reproduce:
1. change in Mate-Tweak the Window Manager (e.g. marco-no-composite)
2. uninstall mate-tweak
3. re-login in mate
=> Problems now: "missing window manager" (effects: e.g. window title missing, can't move / change window ,.. )

The window-manager is still set to old value (e.g. marco-no-composite). But these files were uninstalled.

-----
Alternative Fix/solution: inside of Mate Session Manager:
Mate could detect the missing window-manager and reset it. This would also help in case of uninstall compiz (which may/should have the same problem).
 I've simultaneously opened an [ feature request about it on mate-session-manager](https://github.com/mate-desktop/mate-session-manager/issues/324).

Tested with:   MATE general version: 1.26.2   ;   Linux Distribution: Debian 13