### PR TITLE
remove deprecated window-manager xr_glx_hybrid (bugfix #105)

### DIFF
--- a/data/marco-xr_glx_hybrid.desktop
+++ b/data/marco-xr_glx_hybrid.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Marco (picom: Hybrid)
+Name=Marco (picom: Hybrid) (it is outdated ; now just a migration to default)
 Exec=marco-xr_glx_hybrid
 NoDisplay=true
 # name of loadable control center module

--- a/marco-wrapper
+++ b/marco-wrapper
@@ -17,7 +17,7 @@ case ${BACKEND} in
   no-composite)
     COMP=""
     ;;
-  xrender|glx|xr_glx_hybrid)
+  xrender|glx)
     COMP="picom"
     ;;
   *)

--- a/marco-xr_glx_hybrid
+++ b/marco-xr_glx_hybrid
@@ -1,1 +1,13 @@
-marco-wrapper
+#!/usr/bin/env bash
+#
+# Migrate to default windowmanager ; Because outdated
+#
+# This file "marco-xr_glx_hybrid" is deprecated (since picom v10), and just for migration.
+#  Please keep this file, to be backward-compatible
+#    (in case this window-manager was selected once by user ; Otherwise these users does not have any windowmanager ; currently there is no fallback to default in Mate)
+#  The Changes done by picom in version v10 (Nov 14, 2022) are:
+#   - the backend "xr_glx_hybrid" is marked as deprecated and "will eventually be removed".
+#   - a new parameter is required to start it ("--legacy-backends").
+
+gsettings reset org.mate.session.required-components windowmanager
+marco

--- a/mate-tweak
+++ b/mate-tweak
@@ -420,11 +420,11 @@ class MateTweak:
             self.kill_process('marco')
 
         # If switching away from a picom/compton compositor then kill the compositor
-        if ('xrender' in self.current_wm) or ('glx' in self.current_wm) or ('xr_glx_hybrid' in self.current_wm)  or ('compton' in self.current_wm):
+        if ('xrender' in self.current_wm) or ('glx' in self.current_wm) or ('compton' in self.current_wm):
             self.kill_process('compton')
             self.kill_process('picom')
 
-        if ('xrender' in new_wm) or ('glx' in new_wm) or ('xr_glx_hybrid' in new_wm) or ('no-composite' in new_wm):
+        if ('xrender' in new_wm) or ('glx' in new_wm) or ('no-composite' in new_wm):
             # Disable Marco's compositor when using a 3rd party compositor
             self.set_bool('org.mate.Marco.general', None, 'compositing-manager', False)
             subprocess.Popen([new_wm], stdout=DEVNULL, stderr=DEVNULL)
@@ -1174,8 +1174,6 @@ class MateTweak:
                 wms.append([_("Marco (picom: Xrender)"), 'marco-xrender'])
             if self.find_on_path('marco-glx'):
                 wms.append([_("Marco (picom: GLX)"), 'marco-glx'])
-            if self.find_on_path('marco-xr_glx_hybrid'):
-                wms.append([_("Marco (picom: Hybrid)"), 'marco-xr_glx_hybrid'])
         if self.compiz_capable:
             wms.append([_("Compiz (Advanced GPU accelerated desktop effects)"), 'compiz'])
 


### PR DESCRIPTION
will fix issue #105 :
> The option Window-Manager `xr_glx_hybrid` in MateTweak is current not working anymore.
> That's because of changes by picom [v10 (Nov 14, 2022)](https://github.com/yshui/picom/releases/tag/v10-rc1):
>    - the backend `xr_glx_hybrid` is marked as deprecated and "will eventually be removed".
>   - a new parameter is required to start it (`--legacy-backends`).

---------------
This Pull-Request:
The new file `marco_xr_glx_hybrid` will do a migration to default.
That migration to default is needed. Otherwise these users are without any active window-manager at all. ( Marco does not have a fallback to default. )
