### PR TITLE
mark default windowmanager

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -1168,7 +1168,7 @@ class MateTweak:
                         break
             except:
                 pass
-            wms.append([_("Marco (built-in: "+compositor+")"), 'marco'])
+            wms.append([_("Marco ")+"("+_("built-in")+": "+compositor+")"+' - MATE '+_("default setting"), 'marco'])
         if self.marco_picom_capable and not self.software_rasterizer:
             if self.find_on_path('marco-xrender'):
                 wms.append([_("Marco (picom: Xrender)"), 'marco-xrender'])

--- a/po/de.po
+++ b/po/de.po
@@ -42,6 +42,14 @@ msgstr ""
 msgid "Marco (No compositor)"
 msgstr "Marco (kein Komposit)"
 
+#: ../mate-tweak:1218
+msgid "build-in"
+msgstr "eingebaut"
+
+#: ../mate-tweak:1218
+msgid "default setting"
+msgstr "voreinstellung"
+
 #: ../mate-tweak:1220
 msgid "Marco (Adaptive compositor)"
 msgstr "Marco (anpassungsfähiger Komposit)"

--- a/po/mate-tweak.pot
+++ b/po/mate-tweak.pot
@@ -37,6 +37,14 @@ msgstr ""
 msgid "Marco (No compositor)"
 msgstr ""
 
+#: ../mate-tweak:1218
+msgid "build-in"
+msgstr ""
+
+#: ../mate-tweak:1218
+msgid "default setting"
+msgstr ""
+
 #: ../mate-tweak:1220
 msgid "Marco (Adaptive compositor)"
 msgstr ""


### PR DESCRIPTION
Text-change in drop-down list:
Marco (build-in: Xpresent) **- MATE default setting**

This makes is more easy to find the factory default option, especially for inexperienced user (e.g. in case of error / wrong click).
