### PR TITLE
picom shouldn't run, parallel with compiz or no-composite (bugfix #97)

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -413,6 +413,10 @@ class MateTweak:
                 # FIXME! Don't assume 'metacity' is 1
                 self.set_enum('org.gnome.metacity.theme', None, 'type', 1)
 
+        # If switching to Compiz
+        if new_wm == 'compiz': # in case of change from marco-no-compositor: picom was maybe unwanted autostarted
+            self.kill_process('picom')
+
         # If switching away from a Compiz or Marco window manager kill the window manager
         if 'compiz' in self.current_wm:
             self.kill_process('compiz')

--- a/mate-tweak
+++ b/mate-tweak
@@ -417,6 +417,12 @@ class MateTweak:
         if new_wm == 'compiz': # in case of change from marco-no-compositor: picom was maybe unwanted autostarted
             self.kill_process('picom')
 
+        # no-composite and picom shouldn't run parallel
+        config_dir = GLib.get_user_config_dir()
+        config_file_picom = config_dir + "/picom.conf"
+        if ('no-composite' in new_wm) and os.path.exists('/etc/xdg/autostart/picom.desktop') and os.path.exists(config_file_picom):
+            self.confirm_dialog(_("'No composite' may not work"), _("After you re-login in MATE: Maybe the composite system will start again.\nReason: You have this config file:") + config_file_picom + "\n" + _("This can result in an unwanted autostart of picom.\n(depends on the concret system-wide autostart files of your distribution.)")) # just as workaround (dialog bug: both unwanted cancel button (no effect))
+
         # If switching away from a Compiz or Marco window manager kill the window manager
         if 'compiz' in self.current_wm:
             self.kill_process('compiz')


### PR DESCRIPTION
The autostart of picom resulted in problems with compiz or marco-no-composite.
The autostart was active in these situations:
 - In case of existing ~/.config/picom.conf , or
 - In case of older picom version (< v12)

This will Bugfix #97.

 Parts:
 - when change to compiz: pkill picom.
 - when change to marco-no-composite: inform user about problematic autostart of picom. 


**For the future: disable the autostart of picom?**
I suggest to disable the autostart of picom. When [another Pull-Request](#114 ) was merge, we can continue here:
Replace `Dialog` with `self.disable_autostart('picom.desktop', 'Reason: parallel running will not disable composite.')` [in code view](https://github.com/ubuntu-mate/mate-tweak/commit/26db86f5feee74873d0b3ae5f15dbbbe3c44dd69)