### PR TITLE
minimal changes (6): deprecated part ; missing check at layout opensuse ; keep history-last-run ; active compiz was not detected ; check Layout saved ; check exists before remove

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -1263,6 +1263,7 @@ class MateTweak:
             self.add_to_panel_list(panels, "Netbook", "netbook-no-indicators")
 
         if self.panel_layout_exists('opensuse') and \
+           self.mate_menu_available and \
            not self.indicators_available:
             self.add_to_panel_list(panels, "openSUSE", "opensuse")
 

--- a/mate-tweak
+++ b/mate-tweak
@@ -1384,6 +1384,8 @@ class MateTweak:
             if self.confirm_dialog(title, text):
                 mate_tweak_helper = os.path.join('/','usr', 'lib', 'mate-tweak', 'mate-tweak-helper')
                 delete = subprocess.call(['pkexec', mate_tweak_helper, 'delete', old_layout], stdout=DEVNULL, stderr=DEVNULL)
+                if os.path.exists(os.path.join('/', 'usr', 'share', 'mate-panel', 'layouts', old_layout + '.layout')):
+                    return
                 Notify.init(_('MATE Tweak'))
                 delete_panel_notify=Notify.Notification.new (_('Panel Layout Deleted'),_('Your panel layout has been deleted: ') + old_layout.replace('-tweak','') , 'dialog-information')
                 delete_panel_notify.show()
@@ -1418,6 +1420,8 @@ class MateTweak:
             if self.dock_enabled:
                 dock = subprocess.call([mate_tweak_helper, 'dock', layoutname], stdout=DEVNULL, stderr=DEVNULL)
             install = subprocess.call(['pkexec', mate_tweak_helper, 'install', layoutname], stdout=DEVNULL, stderr=DEVNULL)
+            if not os.path.exists(os.path.join('/', 'usr', 'share', 'mate-panel', 'layouts', layoutname + '.layout')):
+                return
             Notify.init(_('MATE Tweak'))
             save_panels_notify=Notify.Notification.new (_('Panel Layout Saved'),_('Your panel layout has been saved as ') + layoutname.replace('-tweak',''), 'dialog-information')
             save_panels_notify.show()

--- a/mate-tweak
+++ b/mate-tweak
@@ -681,14 +681,17 @@ class MateTweak:
         pid = subprocess.Popen(['mate-settings-daemon', '--replace'], stdout=DEVNULL, stderr=DEVNULL).pid
 
     def confirm_dialog(self, title, text):
-        dialog = Gtk.Dialog(title, None, Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-             Gtk.STOCK_OK, Gtk.ResponseType.OK))
-
+        dialog = Gtk.Dialog(title, None)
+        dialog.set_destroy_with_parent(True)
+        dialog.set_modal(True)
+        dialog.add_buttons(
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OK, Gtk.ResponseType.OK
+        )
         dialog.set_default_size(500, 160)
 
-        label = Gtk.Label(text)
-        label.set_use_markup(True)
+        label = Gtk.Label()
+        label.set_markup(text)
 
         box = dialog.get_content_area()
         box.set_border_width(12)
@@ -1334,14 +1337,17 @@ class MateTweak:
         title = _('Panel layout name')
         text = _('Enter the name for your panel layout.')
 
-        dialog = Gtk.Dialog(title, None, Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
-            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-             Gtk.STOCK_OK, Gtk.ResponseType.OK))
-
+        dialog = Gtk.Dialog(title, None)
+        dialog.set_destroy_with_parent(True)
+        dialog.set_modal(True)
+        dialog.add_buttons(
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OK, Gtk.ResponseType.OK
+        )
         dialog.set_default_size(250, 120)
 
-        label = Gtk.Label(text)
-        label.set_use_markup(True)
+        label = Gtk.Label()
+        label.set_markup(text)
 
         box = dialog.get_content_area()
         box.set_border_width(8)

--- a/mate-tweak
+++ b/mate-tweak
@@ -310,7 +310,8 @@ class MateTweak:
 
         # Make sure any system desktop files are also removed
         mate_tweak_helper = os.path.join('/','usr', 'lib', 'mate-tweak', 'mate-tweak-helper')
-        subprocess.call(['pkexec', mate_tweak_helper, 'autostop', filename], stdout=DEVNULL, stderr=DEVNULL)
+        if os.path.exists(os.path.join('/', 'etc', 'xdg', 'autostart',filename)):
+            subprocess.call(['pkexec', mate_tweak_helper, 'autostop', filename], stdout=DEVNULL, stderr=DEVNULL)
 
     def check_wm_features(self):
         screen = Gdk.Screen.get_default()

--- a/mate-tweak
+++ b/mate-tweak
@@ -323,7 +323,7 @@ class MateTweak:
                 self.current_wm = self.get_string('org.mate.session.required-components', None, 'windowmanager')
             elif not composite_enabled:
                 self.current_wm += '-no-composite'
-        elif ('Compiz' in current_wm):
+        elif ('compiz' in current_wm.lower()):
             self.current_wm = current_wm.lower()
         else:
             self.current_wm = 'Unknown'

--- a/mate-tweak
+++ b/mate-tweak
@@ -795,12 +795,15 @@ class MateTweak:
 
         # If we have a custom panel layout just replace the dconf dump.
         if os.path.exists(os.path.join('/','usr','share','mate-panel','layouts', new_layout + '.panel')):
+            history_last_run = self.get_dconf_value('/org/mate/panel/general/history-mate-run')
             # Reset panel configuration to defaults.
             self.reset_dconf_path('/org/mate/panel/objects/')
             self.reset_dconf_path('/org/mate/panel/toplevels/')
             print('Loading additional panel configuration for ' + new_layout)
             cmd = 'dconf load /org/mate/panel/ < /usr/share/mate-panel/layouts/' + new_layout + '.panel'
             subprocess.call(cmd, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+            self.reset_dconf_path('/org/mate/panel/general/history-mate-run')
+            self.set_dconf_value('/org/mate/panel/general/history-mate-run', history_last_run) #restore
         else:
             # Set the new layout
             subprocess.call(['mate-panel', '--reset', '--layout', new_layout], stdout=DEVNULL, stderr=DEVNULL)


### PR DESCRIPTION
6 (mostly) unimportant changes:

----

1.) **Deprecated gtk parameter updated**:
Update to GTK Parameters, to remove these deprecated warnings:
```
/usr/bin/mate-tweak:684: PyGTKDeprecationWarning: The "buttons" argument must be a Gtk.buttons enum value. Please use the "add_buttons" method for adding buttons. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  dialog = Gtk.Dialog(title, None, Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
/usr/bin/mate-tweak:684: PyGTKDeprecationWarning: The "flags" argument for dialog construction is deprecated. Please use initializer keywords: modal=True and/or destroy_with_parent=True. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  dialog = Gtk.Dialog(title, None, Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
/usr/bin/mate-tweak:690: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  label = Gtk.Label(text)
```
----

2.) **For layout `Opensuse` is `mate-menu` required**:
It has `MateMenuAppletFactory::MateMenuApplet` (see in [layout-file Opensuse](https://github.com/mate-desktop/mate-panel/blob/master/data/opensuse.layout)).
Problem results in: I don't see there any Menu at Debian, without installing that package.
Suggest: Distributions should add `mate-menu` as suggested package (for mate-tweak).

This is an re-opened of an already closed pull Request (i realized afterwards): 
"add mate_menu dependency on opensuse layout": #72 
>  flexiondotorg wrote: "The opensuse layout is legacy, and not dependaent on MATE Menu."

But, I thinks this was wrongly closed.

----

3.) **Keep history-last-run**:

This keeps the current run program history of the user, while changing the Panel.

----

4.)  **Active `compiz` was not detected**

Active Windowmanager compiz was not correct detected, after opening Mate-Tweak once again: The Buttons for Reset and CCSM was missing and red text ".. unknown and unsupported windowmanager. ...".
Problem is: variable current_wm='compiz', but is checked for 'Compiz' (initial letter different).
I changed the code, to be not case-sensitive anymore.

----

5.) **Check Layout saved / deleted**
If layout was not saved or deleted, stop continue.
Use-Case: That could happened, if pkexec failed: The distribution opensuse does not include the policy-file, therefore it will ask for password. The User could cancel (or fail) that password request.

----

6.) **check exist before remove a system-wide autostart**
Check if the autostart file exists, before remove them ( = calling `pkexec mate_tweak_helper autostop ...` ).
This will result in less actions with Root-Right.
Use-Case: The distribution opensuse does not ship the policy-file (= So, every root-request a needs password ).