### PR TITLE
offer fallback from HiDPI on low resolution displays

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -1007,6 +1007,31 @@ class MateTweak:
             time.sleep(0.5)
             if not self.process_running('mate-panel'):
                 self.reload_panel()
+            # May offer a fallback at low resolution displays
+            if self.builder.get_object("combobox_hidpi_scaling").get_active() > 1 :
+                title = _('confirm window scaling factor')
+                text = _('Do you want to keep this new setting?')+"\n("+_("Tip: Move windows by press and hold:")+" "+_("ALT + Mouse-Click (left)")+")"
+                scale_factor_new = value
+                screen = self.window.get_screen()
+                monitor_id = 0 # will only checking the first monitor in newer version of gdk (v4)
+                if hasattr(screen, 'get_active_window') and callable(screen.get_active_window): # get_active_window is deprecated since version 3.22
+                    if(screen.get_active_window()!=None): # with time.sleep(5) before, you got here None
+                        monitor_id = screen.get_monitor_at_window(screen.get_active_window())
+                # Gdk.Display has still the old values
+                resolution_old = Gdk.Display.get_default().get_monitor( monitor_id ).get_geometry()
+                scale_factor_old__monitor = Gdk.Display.get_default().get_monitor( monitor_id ).get_scale_factor()
+                resolution_new_height = resolution_old.height * scale_factor_old__monitor
+                if(scale_factor_new>0): resolution_new_height = resolution_old.height/scale_factor_new
+                resolution_new_width = resolution_old.width * scale_factor_old__monitor
+                if(scale_factor_new>0): resolution_new_width = resolution_old.width/scale_factor_new
+                if resolution_new_height < self.window.get_size()[0] or resolution_new_width < self.window.get_size()[1] :
+                    if not self.confirm_dialog(title, text):
+                        # change scale factor to auto-detect (=0)
+                        self.set_int(schema, None, key, 0)
+                        self.builder.get_object("combobox_hidpi_scaling").set_active(0)
+                        time.sleep(0.5)
+                        if not self.process_running('mate-panel'):
+                            self.reload_panel()
 
         elif schema == "org.mate.panel" and key == "default-layout":
             panel_layout = value

--- a/po/de.po
+++ b/po/de.po
@@ -22,6 +22,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: ../mate-tweak:
+msgid "confirm window scaling factor"
+msgstr "bestätige Fensterskalierung"
+
+#: ../mate-tweak:
+msgid "Do you want to keep this new setting?"
+msgstr "Möchten Sie diese Einstellung beibehalten?"
+
+#: ../mate-tweak:
+msgid "Tip: Move windows by press and hold:"
+msgstr "Tipp: Bewegen von Fenstern über drücken und halten von:"
+
+#: ../mate-tweak:
+msgid "ALT + Mouse-Click (left)"
+msgstr "ALT + Maus-Klick (links)"
+
 #: ../mate-tweak:1207
 msgid "Right"
 msgstr "Rechts"

--- a/po/mate-tweak.pot
+++ b/po/mate-tweak.pot
@@ -17,6 +17,22 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../mate-tweak:
+msgid "confirm window scaling factor"
+msgstr ""
+
+#: ../mate-tweak:
+msgid "Do you want to keep this new setting?"
+msgstr ""
+
+#: ../mate-tweak:
+msgid "Tip: Move windows by press and hold:"
+msgstr ""
+
+#: ../mate-tweak:
+msgid "ALT + Mouse-Click (left)"
+msgstr ""
+
 #: ../mate-tweak:1207
 msgid "Right"
 msgstr ""


### PR DESCRIPTION
In case of unsuitable scale factor set: Offer the user an easy way to switch back.

Issue situation:
 - If the User set HiDPI on a low resolution display, its hard to revert this change.
 - Thats because of, the respective UI are now not visible anymore.
 - The most Users don't know how handle this problem (=to make the UI parts visible):
   - move a window by hotkey: ALT + Mouse-click
   - not possible in another way (=> not possible by right click on Window-Decoration-Header/Title -> move window  )


I've added a new dialog _( Screenshot from 1280 x 800 pixel monitor )_:
<img width="1280" height="800" alt="Screenshot fallback dialog" src="https://github.com/user-attachments/assets/1ca172b7-1ae7-44da-a9b6-33458348bd84" />

<details>
<summary>Dialog as Text</summary>
Title: confirm window scaling factor
Text: Do you want to keep this new setting?
( Tip: Move windows by press and hold: ALT + Mouse-Click (left) )
</details>

The dialog will be only shown, when
 - change to Hi-DPI
 - if the Mate-Tweak window will not fit in new screen size (_rought_)
 - it check the current used monitor. In later version of GDK (>3), it will only check the first monitor.