### PR TITLE
rework: autostart managment: disable autostart by overwrite with a local file, instead of delete the system-wide

### DIFF
--- a/mate-tweak
+++ b/mate-tweak
@@ -574,7 +574,7 @@ class MateTweak:
     def enable_dock(self):
         self.set_string('org.mate.session.required-components', None, 'dock', self.dock)
         if self.dock:
-            self.remove_autostart(self.dock + '.desktop')
+            self.disable_autostart(self.dock + '.desktop')
 
         # Docks require compositing
         schema = None
@@ -602,7 +602,7 @@ class MateTweak:
 
         self.set_string('org.mate.session.required-components', None, 'dock', '')
         if self.dock:
-            self.remove_autostart(self.dock + '.desktop')
+            self.disable_autostart(self.dock + '.desktop')
         self.kill_process(self.dock)
         self.dock_enabled = False
 
@@ -621,7 +621,7 @@ class MateTweak:
 
     def enable_pulldown_terminal(self):
         if self.pulldown_terminal == 'tilda':
-            self.create_autostart(self.pulldown_terminal + '.desktop', __TILDA__)
+            self.enable_autostart(self.pulldown_terminal + '.desktop', __TILDA__)
 
             # Launch tilda, if it is not already enabled.
             if not self.pulldown_terminal_enabled:
@@ -630,7 +630,7 @@ class MateTweak:
 
     def disable_pulldown_terminal(self):
         if self.pulldown_terminal == 'tilda':
-            self.remove_autostart(self.pulldown_terminal + '.desktop')
+            self.disable_autostart(self.pulldown_terminal + '.desktop')
 
         if self.process_running(self.pulldown_terminal):
             self.kill_process(self.pulldown_terminal)
@@ -643,7 +643,7 @@ class MateTweak:
         or hiding.
         """
         self.kill_process('mate-volume-control-applet')
-        self.remove_autostart('mate-volume-control-applet.desktop')
+        self.disable_autostart('mate-volume-control-applet.desktop')
         if os.path.exists('/usr/libexec/ayatana-indicator-power/ayatana-indicator-power-service'):
             self.set_string('org.mate.power-manager', None, 'icon-policy', 'never')
             self.set_bool('org.mate.power-manager', None, 'notify-low-capacity', False)
@@ -659,7 +659,7 @@ class MateTweak:
         """
         pid = subprocess.Popen(['mate-volume-control-applet'], stdout=DEVNULL, stderr=DEVNULL).pid
         self.remove_autostart('mate-volume-control-applet.desktop')
-        self.create_autostart('mate-volume-control-applet.desktop', __APPLET_SOUND__)
+        self.enable_autostart('mate-volume-control-applet.desktop', __APPLET_SOUND__)
         if os.path.exists('/usr/libexec/ayatana-indicator-power/ayatana-indicator-power-service'):
             self.set_string('org.mate.power-manager', None, 'icon-policy', 'present')
             self.set_bool('org.mate.power-manager', None, 'notify-low-capacity', True)

--- a/mate-tweak
+++ b/mate-tweak
@@ -312,6 +312,95 @@ class MateTweak:
         mate_tweak_helper = os.path.join('/','usr', 'lib', 'mate-tweak', 'mate-tweak-helper')
         subprocess.call(['pkexec', mate_tweak_helper, 'autostop', filename], stdout=DEVNULL, stderr=DEVNULL)
 
+    def enable_autostart(self, filename, content=""):
+        if self.has_active_autostart(filename):
+           return
+        # Enable autostart by remove local disabled .desktop file
+        config_dir = GLib.get_user_config_dir()
+        self.mkdir_p(os.path.join(config_dir, 'autostart/'))
+        local_autostart = os.path.join(config_dir, 'autostart', filename)
+        system_autostart = os.path.join('/', 'etc', 'xdg', 'autostart', filename) # missed check of: /usr/share/mate/autostart and /usr/share/autostart
+        if os.path.exists(system_autostart) and self.activ_desktopfile(system_autostart):
+            # the system-wide autostart is ok, but looks overwritten by local
+            if os.path.exists(local_autostart) and self.inactiv_desktopfile(local_autostart):
+                os.remove(local_autostart)
+                return
+        else:
+            # the system-wide autostart is not found / not working
+            if content == "":
+                print("Error: failed to create Autostart (missing content) "+filename)
+                return
+            with open(local_autostart,'w') as out_file:
+                out_file.write(content)
+
+    def disable_autostart(self, filename, comment_add=""):
+        if not self.has_active_autostart(filename):
+           return
+        # Disable autostart by local overwrite .desktop file
+        config_dir = GLib.get_user_config_dir()
+        self.mkdir_p(os.path.join(config_dir, 'autostart/'))
+        local_autostart = os.path.join(config_dir, 'autostart', filename)
+        system_autostart = os.path.join('/', 'etc', 'xdg', 'autostart', filename)
+        if os.path.exists(local_autostart) and self.activ_desktopfile(local_autostart):
+            os.remove(local_autostart)
+        if os.path.exists(system_autostart) and self.activ_desktopfile(system_autostart):
+            self.copy_system_autostart_to_local_and_disable(system_autostart, local_autostart, comment_add)
+
+    def has_active_autostart(self, filename):
+        config_dir = GLib.get_user_config_dir()
+        local_autostart = os.path.join(config_dir, 'autostart', filename)
+        system_autostart = os.path.join('/', 'etc', 'xdg', 'autostart', filename) # missed check of: /usr/share/mate/autostart and /usr/share/autostart
+        if os.path.exists(local_autostart):
+           if self.activ_desktopfile(local_autostart):
+               return True
+        else:
+           if os.path.exists(system_autostart) and self.activ_desktopfile(system_autostart):
+               return True
+        return False
+
+    def copy_system_autostart_to_local_and_disable(self, in_filename_with_path, out_filename_with_path, comment_add=""):
+        # copy a .desktop file and make inactiv (= will not autostart ; by "hidden:true") and add addational text to comment
+        comment_add = "(" + _("disabled by Mate-Tweak.") + " "+comment_add + ") "
+        input_file = open(in_filename_with_path, "r")
+        output_file = open(out_filename_with_path, "w")
+        for line in input_file:
+            if len(line) > 8 and line[0:7] == "Comment":
+                line = line.replace('=', '='+comment_add, 1)
+            if len(line) > 8 and line[0:6] == "Hidden=":
+                continue
+            output_file.write(line)
+        input_file.close()
+        output_file.write("Hidden=true\n");
+        output_file.write("# "+_("created by MateTweak: This overwrites the system-wide autostart.")+" "+comment_add+"\n")
+        output_file.close()
+
+    def inactiv_desktopfile(self, filename_with_path):
+        # check if .desktop file is disabled (= will not autostart )
+        if os.path.exists(filename_with_path):
+            with open(filename_with_path, 'r') as txt:
+                for line in txt:
+                    line = line.replace(' ', '').replace("\t", '')
+                    if line.find('#') != -1:
+                        if line.find('#') > 2:
+                            line = line[:line.find('#')-1]
+                        else:
+                            continue
+                    if line.find('Hidden=true') != -1:
+                        return True
+                    if line.find('NotShowIn') != -1:
+                        if line.find('=MATE') != -1 or line.find(';MATE') !=- 1:
+                            return True
+                    if line.find('OnlyShowIn') != -1 and len(line) > 12:
+                        if line.find('=MATE') == -1 and line.find(';MATE') ==- 1:
+                            return True
+        else:
+            print("file not found to check: " + filename_with_path)
+            return True
+        return False
+
+    def activ_desktopfile(self, filename_with_path):
+        return not self.inactiv_desktopfile(filename_with_path)
+
     def check_wm_features(self):
         screen = Gdk.Screen.get_default()
         current_wm = GdkX11.X11Screen.get_window_manager_name(screen)

--- a/po/de.po
+++ b/po/de.po
@@ -22,6 +22,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: ../mate-tweak:
+msgid "created by MateTweak: This overwrites the system-wide autostart."
+msgstr "erstellt von MateTweak: Dies überschreibt den System-weiten autostart."
+
+#: ../mate-tweak:
+msgid "disabled by Mate-Tweak."
+msgstr "deaktiviert von Mate-Tweak."
+
+#: ../mate-tweak:
+msgid "Reason: parallel running compiz has problems"
+msgstr "Grund: wenn es gleichzeitig mit compiz läuft, gibt es probleme"
+
+#: ../mate-tweak:
+msgid "Reason: ayatana-indicator has already a volume controller"
+msgstr "Grund: ayatana-indicator hat bereits ein Lautstärke Regler"
+
 #: ../mate-tweak:1207
 msgid "Right"
 msgstr "Rechts"

--- a/po/mate-tweak.pot
+++ b/po/mate-tweak.pot
@@ -17,6 +17,22 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../mate-tweak:
+msgid "created by MateTweak: This overwrites the system-wide autostart."
+msgstr ""
+
+#: ../mate-tweak:
+msgid "disabled by Mate-Tweak."
+msgstr ""
+
+#: ../mate-tweak:
+msgid "Reason: parallel running compiz has problems"
+msgstr ""
+
+#: ../mate-tweak:
+msgid "Reason: ayatana-indicator has already a volume controller"
+msgstr ""
+
 #: ../mate-tweak:1207
 msgid "Right"
 msgstr ""


### PR DESCRIPTION
I suggest a change in the Autostart-Managment inside of Mate-Tweak:
Currently the Autostart-files are System-wide deleted (/etc/xdg/autostart) .
I think the overwriting with files in User-Folder is a bedder option (~/.config/autostart) .
Disable of an system-wide Autostart, will be done by overwriting the system-wide. Just simple add the line `Hidden=True` to the .desktop file in ~/.config/autostart to disable the autostart.

Pro-Arguments:
 - less root right needed (note: some distribution does not ship the policy file (like OpenSuse) ; every Layout change need's password)
 - multi-user support (= Users can have different settings)

Autostarts, which are currently changed by Mate-Tweak:
 - toggled on/off :
   - `mate-volume-control-status-icon` (( or the outdated mate-volume-control-applet))
   - `tilda`
 - only to disable (once):
   - the new added: `picom` ( see open Pull-request #108 )

---------
Realization:

We will only write to `~/.config/autostart`. (with exception for the outdated / deprecated parts)

`picom`:
Here we have to make a check before: Some distribution (named: opensuse) added the line `OnlyShowIn=LXQt`, which will disable the autostart in MATE.

Copy / duplicate the systemwide- autostart:
Instead of creating the Autostart-file new, i use a copy of the system-wide one ( if possible ).
Advantage: It has multiple languages for Name or Comment.

The Autostarter are still visible in the autostart managment ( `mate-session-properties` : click checkbox: show hidden). This comment is added:
(disabled by Mate-Tweak. Reason: parallel running compiz has problems)
(disabled by Mate-Tweak. Reason: ayatana-indicator has already a volume controller)
<img width="706" height="691" alt="autostart_vol_hidden__marked_sw_DE_v1_16f" src="https://github.com/user-attachments/assets/5a44e81b-35a1-457b-b46f-42dd286f2820" />